### PR TITLE
fix broken deploy, needs env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: dyno_image_repository
-          IMAGE_TAG: ${{ GITHUB_RUN_NUMBER }}
+          IMAGE_TAG: ${{ env.GITHUB_RUN_NUMBER }}${{ env.GITHUB_RUN_ATTEMPT }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: dyno_image_repository
-          IMAGE_TAG: ${{ env.GITHUB_RUN_NUMBER }}${{ env.GITHUB_RUN_ATTEMPT }}
+          IMAGE_TAG: ${{ env.GITHUB_SHA }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
The github action deploy action is broken. it is because the image tag is using an environment variable but does reference the top level env object first in the template. After review it was mentioned to use the git id, so the  environment variable is changed to that. Ref doc https://docs.github.com/en/actions/learn-github-actions/environment-variables