### PR TITLE
add alias

### DIFF
--- a/terraform/aws_only/ecr.tf
+++ b/terraform/aws_only/ecr.tf
@@ -2,6 +2,10 @@ resource "aws_kms_key" "ecr_kms" {
   enable_key_rotation = true
 }
 
+resource "aws_kms_alias" "ecr_kms_alias" {
+  name          = "alias/ecr_kms_alias"
+  target_key_id = aws_kms_key.ecr_kms.key_id
+}
 
 resource "aws_ecr_repository" "image_repository" {
   name                 = "dyno_image_repository"
@@ -13,6 +17,6 @@ resource "aws_ecr_repository" "image_repository" {
 
   encryption_configuration {
     encryption_type = "KMS"
-    kms_key         = aws_kms_key.ecr_kms.key_id
+    kms_key         = aws_kms_alias.ecr_kms_alias.target_key_arn
   }
 }


### PR DESCRIPTION
Because the kms has key rotate turned on it is forcing the ecr to destroyed and rebuilt. The way around that is using a kms key alias which does not change when a key is rotated