### PR TITLE
Support keeping all files in /tmp

### DIFF
--- a/restler/Dockerfile
+++ b/restler/Dockerfile
@@ -1,5 +1,5 @@
 ARG FUNCTION_DIR="/function"
-FROM  mcr.microsoft.com/restlerfuzzer/restler:v7.4.0 as build-image
+FROM  mcr.microsoft.com/restlerfuzzer/restler:v8.5.0 as build-image
 RUN apk add --no-cache \
     python3 \
     python3-dev \
@@ -20,7 +20,7 @@ RUN python3 -m pip install --upgrade pip
 RUN pip3 install \
     --target ${FUNCTION_DIR} \
     awslambdaric
-FROM mcr.microsoft.com/restlerfuzzer/restler:v7.4.0
+FROM mcr.microsoft.com/restlerfuzzer/restler:v8.5.0
 ARG FUNCTION_DIR
 WORKDIR ${FUNCTION_DIR}
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}

--- a/restler/app/app.py
+++ b/restler/app/app.py
@@ -3,21 +3,22 @@ import json
 
 def handler(event, context):
     print("logging started")
-    restler_compile_cmd = "dotnet /RESTler/restler/Restler.dll compile --api_spec /swagger.json"
+    restler_compile_cmd = "dotnet /RESTler/restler/Restler.dll --workingDirPath /tmp  compile --api_spec /tmp/swagger.json "
     restler_fuzz_cmd = r"""
-    dotnet /RESTler/restler/Restler.dll fuzz-lean \
-        --grammar_file Compile/grammar.py \
-        --dictionary_file Compile/dict.json \
-        --settings Compile/engine_settings.json \
+    dotnet /RESTler/restler/Restler.dll --workingDirPath /tmp \
+        fuzz-lean \
+        --grammar_file /tmp/Compile/grammar.py \
+        --dictionary_file /tmp/Compile/dict.json \
+        --settings /tmp/Compile/engine_settings.json \
         --no_ssl
     """
-    with open('/swagger.json', "w") as f:
+    with open('/tmp/swagger.json', "w") as f:
         json.dump(event['swagger_file'],f)
     print("swagger file saved")
     run(restler_compile_cmd, shell=True)
     print("swagger file complied")
     run(restler_fuzz_cmd, shell=True)
     print("fuzzy complete")
-    with open("FuzzLean/ResponseBuckets/runSummary.json", "r") as f:
+    with open("/tmp/FuzzLean/ResponseBuckets/runSummary.json", "r") as f:
         results = json.load(f)        
     return results


### PR DESCRIPTION
RESTLer by default saves in a folder on the root directory, in lambda only the /tmp folder can have files saved to it https://aws.amazon.com/blogs/compute/choosing-between-aws-lambda-data-storage-options-in-web-apps/.
A version bump was required to support the --workingDirPath flag. All outputs are moved into /tmp