### PR TITLE
Upload results s3

### DIFF
--- a/restler/Dockerfile
+++ b/restler/Dockerfile
@@ -19,7 +19,8 @@ COPY app/* ${FUNCTION_DIR}
 RUN python3 -m pip install --upgrade pip
 RUN pip3 install \
     --target ${FUNCTION_DIR} \
-    awslambdaric
+    awslambdaric \
+    boto3
 FROM mcr.microsoft.com/restlerfuzzer/restler:v8.5.0
 ARG FUNCTION_DIR
 WORKDIR ${FUNCTION_DIR}

--- a/restler/app/app.py
+++ b/restler/app/app.py
@@ -6,6 +6,8 @@ import os
 import shutil
 
 def handler(event, context):
+    #Restler consistently tries to save files to working directory
+    #So to avoid read only errors in lambda change wdir to /tmp
     os.chdir("/tmp")
     print("logging started")
     restler_compile_cmd = "dotnet /RESTler/restler/Restler.dll --workingDirPath /tmp  compile --api_spec /tmp/swagger.json "
@@ -25,7 +27,7 @@ def handler(event, context):
     run(restler_compile_cmd, shell=True)
     print("swagger file complied")
     run(restler_fuzz_cmd, shell=True)
-    print("fuzzy complete")
+    print("fuzzing-lean complete")
     s3 = boto3.client("s3")
     bucket_name = os.environ['results_upload_s3_bucket']
     random_prefix = uuid.uuid4()
@@ -33,9 +35,10 @@ def handler(event, context):
     logs_key = f"{random_prefix}/logs.zip"
     shutil.make_archive("/tmp/results", 'zip', "/tmp/FuzzLean")
     shutil.make_archive("/tmp/logs", 'zip', "/tmp/RestlerLogs")
-    response = s3.upload_file("/tmp/results.zip", bucket_name, logs_key)
-    response = s3.upload_file("/tmp/logs.zip", bucket_name, results_key)
-    print(f"S3 upload response: {response}")
+    response_results = s3.upload_file("/tmp/results.zip", bucket_name, logs_key)
+    response_logs = s3.upload_file("/tmp/logs.zip", bucket_name, results_key)
+    print(f"S3 upload response for results: {response_results}")
+    print(f"S3 upload response for logs: {response_logs}")
     with open("/tmp/FuzzLean/ResponseBuckets/runSummary.json", "r") as f:
         results = json.load(f)        
     return results

--- a/restler/app/app.py
+++ b/restler/app/app.py
@@ -1,11 +1,18 @@
+import uuid
 from subprocess import run
 import json
+import boto3
+import os
+import shutil
 
 def handler(event, context):
+    os.chdir("/tmp")
     print("logging started")
     restler_compile_cmd = "dotnet /RESTler/restler/Restler.dll --workingDirPath /tmp  compile --api_spec /tmp/swagger.json "
     restler_fuzz_cmd = r"""
-    dotnet /RESTler/restler/Restler.dll --workingDirPath /tmp \
+    dotnet /RESTler/restler/Restler.dll \
+        --workingDirPath /tmp \
+        --logsUploadRootDirPath /tmp \
         fuzz-lean \
         --grammar_file /tmp/Compile/grammar.py \
         --dictionary_file /tmp/Compile/dict.json \
@@ -19,6 +26,16 @@ def handler(event, context):
     print("swagger file complied")
     run(restler_fuzz_cmd, shell=True)
     print("fuzzy complete")
+    s3 = boto3.client("s3")
+    bucket_name = os.environ['results_upload_s3_bucket']
+    random_prefix = uuid.uuid4()
+    results_key = f"{random_prefix}/results.zip"
+    logs_key = f"{random_prefix}/logs.zip"
+    shutil.make_archive("/tmp/results", 'zip', "/tmp/FuzzLean")
+    shutil.make_archive("/tmp/logs", 'zip', "/tmp/RestlerLogs")
+    response = s3.upload_file("/tmp/results.zip", bucket_name, logs_key)
+    response = s3.upload_file("/tmp/logs.zip", bucket_name, results_key)
+    print(f"S3 upload response: {response}")
     with open("/tmp/FuzzLean/ResponseBuckets/runSummary.json", "r") as f:
         results = json.load(f)        
     return results

--- a/terraform/aws_only/restler.tf
+++ b/terraform/aws_only/restler.tf
@@ -3,6 +3,11 @@ resource "aws_lambda_function" "lambda_restler" {
   image_uri     = var.restler_image_tag
   package_type  = "Image"
   timeout       = var.restler_lambda_timeout
+  environment {
+    variables = {
+    results_upload_s3_bucket = var.fuzz_results_bucket
+  }
+  }
 
   tracing_config {
     mode = "Active"

--- a/terraform/aws_only/restler.tf
+++ b/terraform/aws_only/restler.tf
@@ -5,8 +5,8 @@ resource "aws_lambda_function" "lambda_restler" {
   timeout       = var.restler_lambda_timeout
   environment {
     variables = {
-    results_upload_s3_bucket = var.fuzz_results_bucket
-  }
+      results_upload_s3_bucket = var.fuzz_results_bucket
+    }
   }
 
   tracing_config {

--- a/terraform/aws_only/variables.tf
+++ b/terraform/aws_only/variables.tf
@@ -37,3 +37,9 @@ variable "restler_lambda_timeout" {
   description = "Time out for lambda - Related to SQS Queue visibility"
 
 }
+
+variable "fuzz_results_bucket" {
+  type        = string
+  description = "fuzz output bucket"
+
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,7 @@ module "aws_only" {
   lambda_restler_iam_arn = module.main.lambda_restler_iam_arn
   open_api_sqs_arn       = module.main.open_api_sqs_arn
   restler_lambda_timeout = var.restler_lambda_timeout
+  fuzz_results_bucket = module.main.fuzz_results_bucket
 }
 
 data "aws_canonical_user_id" "current" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,7 +36,7 @@ module "aws_only" {
   lambda_restler_iam_arn = module.main.lambda_restler_iam_arn
   open_api_sqs_arn       = module.main.open_api_sqs_arn
   restler_lambda_timeout = var.restler_lambda_timeout
-  fuzz_results_bucket = module.main.fuzz_results_bucket
+  fuzz_results_bucket    = module.main.fuzz_results_bucket
 }
 
 data "aws_canonical_user_id" "current" {}

--- a/terraform/main/outputs.tf
+++ b/terraform/main/outputs.tf
@@ -20,3 +20,7 @@ output "open_api_sqs_arn" {
   value = aws_sqs_queue.openapi_sqs_queue.arn
 
 }
+
+output "fuzz_results_bucket" {
+  value = aws_s3_bucket.fuzz_results_bucket.id
+}

--- a/terraform/main/restler.tf
+++ b/terraform/main/restler.tf
@@ -42,7 +42,7 @@ resource "aws_iam_policy" "lambda_policy" {
         "s3:GetObjectAcl"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.openapi_files_bucket.arn}"
+      "Resource": ["${aws_s3_bucket.openapi_files_bucket.arn}/*","${aws_s3_bucket.fuzz_results_bucket.arn}/*"]
     },
     {
         "Effect": "Allow",
@@ -69,4 +69,24 @@ EOT
 resource "aws_iam_role_policy_attachment" "lambda_restler" {
   policy_arn = aws_iam_policy.lambda_policy.arn
   role       = aws_iam_role.lambda_restler.name
+}
+
+resource "aws_s3_bucket" "fuzz_results_bucket" {
+  bucket = "${var.deployment_id}-fuzzer-results-comp9447-files"
+}
+
+resource "aws_s3_bucket_versioning" "fuzz_results_bucket_versioning" {
+  bucket = aws_s3_bucket.fuzz_results_bucket.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "fuzz_results_bucket_access" {
+  bucket = aws_s3_bucket.fuzz_results_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }


### PR DESCRIPTION
- Alters Reslter docker upload to s3 bucket with a random prefix (in latter PR is can be overridden if we want an explicit location)
- Create Fuzzer results bucket
- Alter IAM to allow reslter to upload results