### PR TITLE
Fix restler gb collection

### DIFF
--- a/.github/workflows/restler.yml
+++ b/.github/workflows/restler.yml
@@ -1,0 +1,14 @@
+name: Python CI
+on:
+  pull_request:
+    paths:
+      - restler/**
+      - demo_server/**
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: hashicorp/terraform:1.1.6
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+        run: black . --check

--- a/demo_server/demo_server/app.py
+++ b/demo_server/demo_server/app.py
@@ -8,9 +8,9 @@ from sqlmodel import create_engine, SQLModel, Session
 from db import engine, get_session
 from routers import blog, doc
 
-app = FastAPI(title="Demo Blog Server",
-    servers=[
-            {"url": "https://localhost:8888", "description": "Staging environment"}]
+app = FastAPI(
+    title="Demo Blog Server",
+    servers=[{"url": "https://localhost:8888", "description": "Staging environment"}],
 )
 
 app.include_router(blog.router)
@@ -24,15 +24,14 @@ def on_startup():
 
 if __name__ == "__main__":
 
-    app_port = os.getenv('DEMO_SERVER_PORT')
+    app_port = os.getenv("DEMO_SERVER_PORT")
     if isinstance(app_port, int):
         app_port = int(app_port)
     else:
         app_port = 8888
 
-    app_host = os.getenv('DEMO_SERVER_HOST')
+    app_host = os.getenv("DEMO_SERVER_HOST")
     if app_host is None:
         app_host = "0.0.0.0"
 
     uvicorn.run("app:app", reload=True, host=app_host, port=app_port)
-

--- a/demo_server/demo_server/db.py
+++ b/demo_server/demo_server/db.py
@@ -1,8 +1,12 @@
 from sqlmodel import create_engine, Session
 
-engine = create_engine("sqlite:///db.sqlite",
-                       connect_args={"check_same_thread": False, },
-                       echo=True)
+engine = create_engine(
+    "sqlite:///db.sqlite",
+    connect_args={
+        "check_same_thread": False,
+    },
+    echo=True,
+)
 
 
 def get_session():

--- a/demo_server/demo_server/schemas.py
+++ b/demo_server/demo_server/schemas.py
@@ -9,12 +9,7 @@ class BlogPostPublicInput(SQLModel):
     body: str
 
     class Config:
-        schema_extra = {
-            "example": {
-                "id": 99,
-                "body": "my first blog post"
-            }
-        }
+        schema_extra = {"example": {"id": 99, "body": "my first blog post"}}
 
 
 class BlogPostInput(SQLModel):
@@ -26,11 +21,7 @@ class BlogPostInput(SQLModel):
 
     class Config:
         schema_extra = {
-            "example": {
-                "id": 22,
-                "body": "my first blog post",
-                "checksum": "abcde"
-            }
+            "example": {"id": 22, "body": "my first blog post", "checksum": "abcde"}
         }
 
 

--- a/restler/app/app.py
+++ b/restler/app/app.py
@@ -5,9 +5,10 @@ import boto3
 import os
 import shutil
 
+
 def handler(event, context):
-    #Restler consistently tries to save files to working directory
-    #So to avoid read only errors in lambda change wdir to /tmp
+    # Restler consistently tries to save files to working directory
+    # So to avoid read only errors in lambda change wdir to /tmp
     os.chdir("/tmp")
     print("logging started")
     restler_compile_cmd = "dotnet /RESTler/restler/Restler.dll --workingDirPath /tmp  compile --api_spec /tmp/swagger.json "
@@ -21,28 +22,31 @@ def handler(event, context):
         --settings /tmp/Compile/engine_settings.json \
         --no_ssl
     """
-    with open('/tmp/swagger.json', "w") as f:
-        json.dump(event['swagger_file'],f)
+    with open("/tmp/swagger.json", "w") as f:
+        json.dump(event["swagger_file"], f)
     print("swagger file saved")
     run(restler_compile_cmd, shell=True)
-    with open('/tmp/Compile/engine_settings.json','r') as f:
+    with open("/tmp/Compile/engine_settings.json", "r") as f:
         engine_settings = json.load(f)
         engine_settings["garbage_collection_interval"] = 0
-    with open('/tmp/Compile/engine_settings.json','w') as f:
-        json.dump('/tmp/Compile/engine_settings.json')
+    with open("/tmp/Compile/engine_settings.json", "w") as f:
+        json.dump("/tmp/Compile/engine_settings.json")
     print("swagger file complied")
     run(restler_fuzz_cmd, shell=True)
     print("fuzzing-lean complete")
     s3 = boto3.client("s3")
-    bucket_name = os.environ['results_upload_s3_bucket']
+    bucket_name = os.environ["results_upload_s3_bucket"]
     random_prefix = uuid.uuid4()
-    for folder,prefix in [("RestlerLogs","logs"),("FuzzLean","results"),("Compile","compile")]:
+    for folder, prefix in [
+        ("RestlerLogs", "logs"),
+        ("FuzzLean", "results"),
+        ("Compile", "compile"),
+    ]:
         key = f"{random_prefix}/{prefix}.zip"
-        shutil.make_archive(f"/tmp/{prefix}", 'zip', f"/tmp/{folder}")
+        shutil.make_archive(f"/tmp/{prefix}", "zip", f"/tmp/{folder}")
         response = s3.upload_file(f"/tmp/{ prefix }.zip", bucket_name, key)
         print(f"S3 uploaded response for {prefix}: {response}")
         print(f"S3 {prefix} uploaded to s3://{bucket_name}/{key}")
     with open("/tmp/FuzzLean/ResponseBuckets/runSummary.json", "r") as f:
-        results = json.load(f)        
+        results = json.load(f)
     return results
-

--- a/restler/app/app.py
+++ b/restler/app/app.py
@@ -25,20 +25,24 @@ def handler(event, context):
         json.dump(event['swagger_file'],f)
     print("swagger file saved")
     run(restler_compile_cmd, shell=True)
+    with open('/tmp/Compile/engine_settings.json','r') as f:
+        engine_settings = json.load(f)
+        engine_settings["garbage_collection_interval"] = 0
+    with open('/tmp/Compile/engine_settings.json','w') as f:
+        json.dump('/tmp/Compile/engine_settings.json')
     print("swagger file complied")
     run(restler_fuzz_cmd, shell=True)
     print("fuzzing-lean complete")
     s3 = boto3.client("s3")
     bucket_name = os.environ['results_upload_s3_bucket']
     random_prefix = uuid.uuid4()
-    results_key = f"{random_prefix}/results.zip"
-    logs_key = f"{random_prefix}/logs.zip"
-    shutil.make_archive("/tmp/results", 'zip', "/tmp/FuzzLean")
-    shutil.make_archive("/tmp/logs", 'zip', "/tmp/RestlerLogs")
-    response_results = s3.upload_file("/tmp/results.zip", bucket_name, logs_key)
-    response_logs = s3.upload_file("/tmp/logs.zip", bucket_name, results_key)
-    print(f"S3 upload response for results: {response_results}")
-    print(f"S3 upload response for logs: {response_logs}")
+    for folder,prefix in [("RestlerLogs","logs"),("FuzzLean","results"),("Compile","compile")]:
+        key = f"{random_prefix}/{prefix}.zip"
+        shutil.make_archive(f"/tmp/{prefix}", 'zip', f"/tmp/{folder}")
+        response = s3.upload_file(f"/tmp/{ prefix }.zip", bucket_name, key)
+        print(f"S3 uploaded response for {prefix}: {response}")
+        print(f"S3 {prefix} uploaded to s3://{bucket_name}/{key}")
     with open("/tmp/FuzzLean/ResponseBuckets/runSummary.json", "r") as f:
         results = json.load(f)        
     return results
+


### PR DESCRIPTION
- Format with black (all python files in repo)
- Added a github action for a black lint cheaker
- moved print to logger 
- Alter /tmp/Compile/engine_settings.json to set engine_settings["garbage_collection_interval"] = 0
Otherwise reslter will attempt to use multiprocessing python libraries which are not supported in lambda.  See https://stackoverflow.com/questions/34005930/multiprocessing-semlock-is-not-implemented-when-running-on-aws-lambda
- Upload compile folder into s3 (helps debugging)
- convert upload folder to for loop with three paths (compile, logs, results)
- logs print s3 upload location