### PR TITLE
Updated issues tests

### DIFF
--- a/cmd/issues/main.go
+++ b/cmd/issues/main.go
@@ -94,7 +94,7 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) error {
 			panic(err)
 		}
 		bugFileName := strings.Split(f.Name, "/")
-		if len(bugFileName)-1 > 0 {
+		if len(bugFileName) - 1 > 0 {
 			fuzzError := strings.Split(bugFileName[1], "_")
 			if len(fuzzError) > 1 {
 				fileContents, _ := ioutil.ReadAll(read)

--- a/cmd/issues/main.go
+++ b/cmd/issues/main.go
@@ -94,7 +94,7 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) error {
 			panic(err)
 		}
 		bugFileName := strings.Split(f.Name, "/")
-		if len(bugFileName) - 1 > 0 {
+		if len(bugFileName)-1 > 0 {
 			fuzzError := strings.Split(bugFileName[1], "_")
 			if len(fuzzError) > 1 {
 				fileContents, _ := ioutil.ReadAll(read)

--- a/internal/parse/restler_parse.go
+++ b/internal/parse/restler_parse.go
@@ -94,3 +94,13 @@ func createResult(requestSplit []string, scanner *bufio.Scanner, dynoResult *res
 	dynoResult.PreviousResponse = &previousResponse
 	return dynoResult
 }
+
+// GetFuzzError is given the filename as a string and 
+// returns the type of fuzzing error found by the fuzzer
+func GetFuzzError(filename string) []string{
+	fuzzError := strings.Split(filename, "_")
+	if len(fuzzError) <= 1 {
+		panic("FileName: not recognised as a RESTler File")
+	}
+	return strings.Split(filename, "_")
+}

--- a/internal/parse/restler_parse.go
+++ b/internal/parse/restler_parse.go
@@ -95,9 +95,9 @@ func createResult(requestSplit []string, scanner *bufio.Scanner, dynoResult *res
 	return dynoResult
 }
 
-// GetFuzzError is given the filename as a string and 
+// GetFuzzError is given the filename as a string and
 // returns the type of fuzzing error found by the fuzzer
-func GetFuzzError(filename string) []string{
+func GetFuzzError(filename string) []string {
 	fuzzError := strings.Split(filename, "_")
 	if len(fuzzError) <= 1 {
 		panic("FileName: not recognised as a RESTler File")

--- a/internal/parse/restler_parse_test.go
+++ b/internal/parse/restler_parse_test.go
@@ -1,20 +1,20 @@
 package parse_test
 
 import (
+	"os"
 	"dyno/internal/parse"
 	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )
 
-func TestParseRestlerFuzzResultsInvalid(t *testing.T) {
-	fileContents := "../tests/bug_buckets/"
-	fuzzError := strings.Split("example", "example")
-	assert.Panics(t, func() { parse.ParseRestlerFuzzResults(fileContents, fuzzError) })
+func TestParseInvalidFuzzError(t *testing.T) {
+	assert.Panics(t, func() { parse.GetFuzzError("something") })
 }
 func TestParseRestlerFuzzResultsValid(t *testing.T) {
-	fileContents := "../tests/bug_buckets/"
-	fuzzError := strings.Split("example", "example")
+	file, _ := os.ReadFile("../tests/bug_buckets/InvalidDynamicObjectChecker_20x_1.txt")
+	fileContents := string(file)
+	fuzzError := parse.GetFuzzError("InvalidDynamicObjectChecker_20x_1.txt")
 	expectedDynoResults := [11]string{
 		"InvalidDynamicObjectChecker Invalid 20x Response",
 		"InvalidDynamicObjectChecker Invalid 20x Response",
@@ -29,26 +29,35 @@ func TestParseRestlerFuzzResultsValid(t *testing.T) {
 		"UseAfterFreeChecker Invalid 20x Response",
 	}
 	actualDynoResults := parse.ParseRestlerFuzzResults(fileContents, fuzzError)
-	println(*actualDynoResults[0].Title)
-	println(*actualDynoResults[0].Endpoint)
-	println(*actualDynoResults[0].Method)
-	println(*actualDynoResults[0].MethodInformation.AcceptedResponse)
-	println(*actualDynoResults[0].MethodInformation.Host)
-	println(*actualDynoResults[0].MethodInformation.ContentType)
-	println(*actualDynoResults[0].MethodInformation.Request)
-	println(*actualDynoResults[0].TimeDelay)
-	println(*actualDynoResults[0].AsyncTime)
-	println(*actualDynoResults[0].PreviousResponse)
-	println(*actualDynoResults[0].ErrorType)
 	assert.Equal(t, expectedDynoResults[0], *actualDynoResults[0].Title)
 	assert.Equal(t, expectedDynoResults[1], *actualDynoResults[1].Title)
-	assert.Equal(t, expectedDynoResults[2], *actualDynoResults[2].Title)
-	assert.Equal(t, expectedDynoResults[3], *actualDynoResults[3].Title)
-	assert.Equal(t, expectedDynoResults[4], *actualDynoResults[4].Title)
-	assert.Equal(t, expectedDynoResults[5], *actualDynoResults[5].Title)
-	assert.Equal(t, expectedDynoResults[6], *actualDynoResults[6].Title)
-	assert.Equal(t, expectedDynoResults[7], *actualDynoResults[7].Title)
-	assert.Equal(t, expectedDynoResults[8], *actualDynoResults[8].Title)
-	assert.Equal(t, expectedDynoResults[9], *actualDynoResults[9].Title)
-	assert.Equal(t, expectedDynoResults[10], *actualDynoResults[10].Title)
+
+	file, _ = os.ReadFile("../tests/bug_buckets/InvalidDynamicObjectChecker_20x_2.txt")
+	fileContents = string(file)
+	fuzzError = parse.GetFuzzError("InvalidDynamicObjectChecker_20x_2.txt")
+	actualDynoResults = parse.ParseRestlerFuzzResults(fileContents, fuzzError)
+	assert.Equal(t, expectedDynoResults[2], *actualDynoResults[0].Title)
+	assert.Equal(t, expectedDynoResults[3], *actualDynoResults[1].Title)
+
+	file, _ = os.ReadFile("../tests/bug_buckets/PayloadBodyChecker_500_1.txt")
+	fileContents = string(file)
+	fuzzError = parse.GetFuzzError("PayloadBodyChecker_500_1.txt")
+	actualDynoResults = parse.ParseRestlerFuzzResults(fileContents, fuzzError)
+	assert.Equal(t, expectedDynoResults[4], *actualDynoResults[0].Title)
+	assert.Equal(t, expectedDynoResults[5], *actualDynoResults[1].Title)
+
+	file, _ = os.ReadFile("../tests/bug_buckets/PayloadBodyChecker_500_2.txt")
+	fileContents = string(file)
+	fuzzError = parse.GetFuzzError("PayloadBodyChecker_500_2.txt")
+	actualDynoResults = parse.ParseRestlerFuzzResults(fileContents, fuzzError)
+	assert.Equal(t, expectedDynoResults[6], *actualDynoResults[0].Title)
+	assert.Equal(t, expectedDynoResults[7], *actualDynoResults[1].Title)
+	
+	file, _ = os.ReadFile("../tests/bug_buckets/UseAfterFreeChecker_20x_1.txt")
+	fileContents = string(file)
+	fuzzError = parse.GetFuzzError("UseAfterFreeChecker_20x_1.txt")
+	actualDynoResults = parse.ParseRestlerFuzzResults(fileContents, fuzzError)
+	assert.Equal(t, expectedDynoResults[8], *actualDynoResults[0].Title)
+	assert.Equal(t, expectedDynoResults[9], *actualDynoResults[1].Title)
+	assert.Equal(t, expectedDynoResults[10], *actualDynoResults[2].Title)
 }

--- a/internal/parse/restler_parse_test.go
+++ b/internal/parse/restler_parse_test.go
@@ -1,10 +1,9 @@
 package parse_test
 
 import (
-	"os"
 	"dyno/internal/parse"
 	"github.com/stretchr/testify/assert"
-	"strings"
+	"os"
 	"testing"
 )
 
@@ -52,7 +51,7 @@ func TestParseRestlerFuzzResultsValid(t *testing.T) {
 	actualDynoResults = parse.ParseRestlerFuzzResults(fileContents, fuzzError)
 	assert.Equal(t, expectedDynoResults[6], *actualDynoResults[0].Title)
 	assert.Equal(t, expectedDynoResults[7], *actualDynoResults[1].Title)
-	
+
 	file, _ = os.ReadFile("../tests/bug_buckets/UseAfterFreeChecker_20x_1.txt")
 	fileContents = string(file)
 	fuzzError = parse.GetFuzzError("UseAfterFreeChecker_20x_1.txt")


### PR DESCRIPTION
- Updated tests for restler_parse_test as they had broken with the changes to the ParseFuzzResults function when implementing it into a aws lambda