### PR TITLE
Updated issues with fix to reading zip file

### DIFF
--- a/cmd/issues/main.go
+++ b/cmd/issues/main.go
@@ -94,14 +94,12 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) error {
 			panic(err)
 		}
 		bugFileName := strings.Split(f.Name, "/")
-		if len(bugFileName)-1 > 0 {
-			fuzzError := strings.Split(bugFileName[1], "_")
-			if len(fuzzError) > 1 {
-				fileContents, _ := ioutil.ReadAll(read)
-				rawResults := parse.ParseRestlerFuzzResults(string(fileContents), fuzzError)
-				for i := 0; i < len(rawResults); i++ {
-					results = append(results, rawResults[i])
-				}
+		fuzzError := strings.Split(bugFileName[len(bugFileName)-1], "_")
+		if len(fuzzError) > 1 {
+			fileContents, _ := ioutil.ReadAll(read)
+			rawResults := parse.ParseRestlerFuzzResults(string(fileContents), fuzzError)
+			for i := 0; i < len(rawResults); i++ {
+				results = append(results, rawResults[i])
 			}
 		}
 	}

--- a/internal/parse/restler_parse.go
+++ b/internal/parse/restler_parse.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 )
 
+const (
+	RESTLERFILEID = "->"
+)
+
 // Parses the fuzzing files from the bug_buckets folder and creates raw fuzzing results.
 // fileContents is the contents of a file from the s3 bucket object
 // fuzzError is the type of bug found
@@ -20,7 +24,7 @@ func ParseRestlerFuzzResults(fileContents string, fuzzError []string) []result.D
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if len(line) > 1 && line[0:2] == "->" {
+		if len(line) > 1 && line[0:2] == RESTLERFILEID {
 			requestSplit := strings.Split(line, "\\n")
 			dynoMethodInformation := &result.DynoMethodInformation{}
 			dynoMethodInformation = createMethod(requestSplit, dynoMethodInformation)
@@ -100,7 +104,7 @@ func createResult(requestSplit []string, scanner *bufio.Scanner, dynoResult *res
 func GetFuzzError(filename string) []string {
 	fuzzError := strings.Split(filename, "_")
 	if len(fuzzError) <= 1 {
-		panic("FileName: not recognised as a RESTler File")
+		panic("FileName: not recognized as a RESTler File")
 	}
 	return strings.Split(filename, "_")
 }


### PR DESCRIPTION
- Assumptions that were made in creating the lambda function for issues were broken as there were more raw result files than expected
- This change just allows all the files to be read allowing for future changes if there is valuable information restler creates that is needed for better descriptions in the future. 