### PR TITLE
add-deadletter-sqs

### DIFF
--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -19,3 +19,5 @@ provider "aws" {
 data "aws_canonical_user_id" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}


### PR DESCRIPTION
Because we don't have a dead letter queue when messages reach the invisibility timeout after a failed lambda trigger they reappear in the queue triggering the lambda again. Which makes debugging very tricky